### PR TITLE
sort mappings for deterministic and diffable output

### DIFF
--- a/internal/gen.go
+++ b/internal/gen.go
@@ -767,7 +767,8 @@ func (g *generator) Generate() error {
 	var mapperList []*mapper
 	mappersContext := NewMappingContext(mappersAbsPkg)
 
-	for dest, mappings := range dests {
+	for _, dest := range SortedKeys(dests) {
+		mappings := dests[dest]
 		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
 			return err
 		}

--- a/internal/util.go
+++ b/internal/util.go
@@ -2,12 +2,14 @@ package internal
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
 	"go/types"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -388,4 +390,15 @@ func GetParamsCount(f *types.Func) int {
 		return 0
 	}
 	return strings.Count(mm[1], " ")
+}
+
+// SortedKeys returns the keys of the map m.
+func SortedKeys[K cmp.Ordered, V any](in map[K]V) []K {
+	result := make([]K, 0, len(in))
+	for k := range in {
+		result = append(result, k)
+	}
+
+	slices.Sort(result)
+	return result
 }


### PR DESCRIPTION
Thanks for the useful tool!

We use this tool to generate mappings that get checked into the repo, and therefore goes through some review when a mapping is updated. It's much easier to read the diff when a new mapping is added if the existing mappings don't move around.

This PR sorts the mappings in the file, which results in a deterministic output. This also lets us run a CI check to verify that the generated code does not drift from the mapping configuration.

Let me know if you would like me to add some tests for this case.